### PR TITLE
Make duplicate user creation return 409

### DIFF
--- a/__tests__/auth-router_register.spec.js
+++ b/__tests__/auth-router_register.spec.js
@@ -23,12 +23,12 @@ describe('Routers Users', () => {
       expect(newUser).not.toBeNull();
     });
 
-    it('Return 500 on duplicate', async () => {
+    it('Return 409 on duplicate', async () => {
       await request(url, {method, body: user});
 
       const {status, type} = await request(url, {method, body: user});
 
-      expect(status).toEqual(500);
+      expect(status).toEqual(409);
       expect(type).toEqual('application/json');
     });
   });

--- a/__tests__/users-router_update_user.spec.js
+++ b/__tests__/users-router_update_user.spec.js
@@ -127,5 +127,19 @@ describe('Routers Users', () => {
 
       expect(body).toEqual(newUser);
     });
+
+    it('Return 409 on duplicate', async () => {
+      const newUser = createUser({id: 2, email: 'fake@email.com'});
+      await db('users').insert(newUser);
+
+      const {status, type} = await request(`/api/users/${newUser.id}`, {
+        method,
+        token,
+        body: {email: user.email},
+      });
+
+      expect(status).toEqual(409);
+      expect(type).toEqual('application/json');
+    });
   });
 });

--- a/config/errors.js
+++ b/config/errors.js
@@ -11,6 +11,7 @@ const USER_NO_CHANGES_ERROR = 'No changes to update.';
 const UPDATE_USER_ERROR = 'There was an error updating user.';
 const DELETE_USER_ERROR = 'There was an error deleting user.';
 const WRONG_USER_ERROR = 'Wrong user.';
+const DUPLICATE_USER_ERROR = 'User already exists.';
 
 const GET_ALL_REVIEW_ERROR = 'There was an error getting all reviews.';
 const GET_REVIEW_ERROR = 'There was an error getting review.';
@@ -40,6 +41,7 @@ module.exports = {
   UPDATE_USER_ERROR,
   DELETE_USER_ERROR,
   WRONG_USER_ERROR,
+  DUPLICATE_USER_ERROR,
 
   GET_ALL_REVIEW_ERROR,
   GET_REVIEW_ERROR,

--- a/routers/auth-router.js
+++ b/routers/auth-router.js
@@ -7,6 +7,7 @@ const {
   checkForLoginData,
 } = require('../middleware/index.js');
 const signToken = require('../config/token');
+const {DUPLICATE_USER_ERROR} = require('../config/errors');
 
 /**************************************************************************/
 
@@ -73,6 +74,9 @@ router.post('/register', checkForRegisterData, async (req, res) => {
     const token = signToken(newUser);
     res.status(201).json({token, user: newUser});
   } catch (e) {
+    if (e.code === '23505')
+      return res.status(409).json({error: DUPLICATE_USER_ERROR});
+
     console.log(e);
     res.status(500).json({error: 'There was an error signing up.'});
   }

--- a/routers/users-router.js
+++ b/routers/users-router.js
@@ -9,6 +9,7 @@ const {
   UPDATE_USER_ERROR,
   DELETE_USER_ERROR,
   WRONG_USER_ERROR,
+  DUPLICATE_USER_ERROR,
   ADD_REVIEW_ERROR,
   UPDATE_REVIEW_ERROR,
   DELETE_REVIEW_ERROR,
@@ -106,6 +107,9 @@ router.put('/:userId', validateUserId, async (req, res) => {
     const updatedUser = await User.updateUser(user.id, updates);
     res.json(updatedUser);
   } catch (e) {
+    if (e.code === '23505')
+      return res.status(409).json({error: DUPLICATE_USER_ERROR});
+
     console.log(e);
     res.status(500).json({message: UPDATE_USER_ERROR});
   }


### PR DESCRIPTION
# Description

Makes duplicate user creation return a 409 status code instead of 500

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change Status

- [X] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [ ] Jest

# Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
